### PR TITLE
SLC5 container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ There are different sets of Dockerfiles in this repository:
 - [standalone](standalone) images [![](https://images.microbadger.com/badges/image/clelange/cmssw.svg)](https://microbadger.com/images/clelange/cmssw)
 - [cvmfs](cvmfs)-based images [![](https://images.microbadger.com/badges/image/clelange/cmssw-cvmfs.svg)](https://microbadger.com/images/clelange/cmssw-cvmfs) [![](https://images.microbadger.com/badges/version/clelange/cmssw-cvmfs.svg)](https://microbadger.com/images/clelange/cmssw-cvmfs)
 - [slc6-cms](slc6-cms) images [![](https://images.microbadger.com/badges/image/clelange/slc6-cms.svg)](https://microbadger.com/images/clelange/slc6-cms) [![](https://images.microbadger.com/badges/version/clelange/slc6-cms.svg)](https://microbadger.com/images/clelange/slc6-cms)
+- [slc5-cms](slc5-cms) images [![](https://images.microbadger.com/badges/image/clelange/slc5-cms.svg)](https://microbadger.com/images/clelange/slc5-cms) [![](https://images.microbadger.com/badges/version/clelange/slc5-cms.svg)](https://microbadger.com/images/clelange/slc5-cms)
+
 
 The non-standalone images need a network connection, and can be slow, since CMSSW is loaded via the network. The advantage is that they are much smaller (few hundreds of MB) while the standalone images contain the full CMSSW release (>= 15 GB).
 
@@ -50,9 +52,9 @@ make
 make docker_push
 ```
 
-### SLC6-CMS version
+### SLC5/SLC6-CMS version
 
-This image does not know about CMSSW, it is only an SLC6 image with some additional packages installed. CVMFS needs to be mounted as volume (see below):
+This image does not know about CMSSW, it is only an SLC5/SLC6 image with some additional packages installed. CVMFS needs to be mounted as volume (see below):
 
 ```shell
 make
@@ -109,7 +111,7 @@ sudo setenforce 0
 
 This can be changed permanently by editing `/etc/selinux/config`, setting `SELINUX` to `permissive` or `disabled`.
 
-### SLC6-only version
+### SLC5/SLC6-only version
 
 On a machine that has `/cvmfs` mounted (and available to the docker process):
 

--- a/slc5-cms/Dockerfile
+++ b/slc5-cms/Dockerfile
@@ -1,0 +1,75 @@
+# SLC5 OS capable of using/running CMS software release(s).
+
+# Make the base image configurable:
+ARG BASEIMAGE=cern/slc5-base:latest
+
+# Set up the SLC5 CMSSW base:
+FROM ${BASEIMAGE}
+
+LABEL maintainer="Clemens Lange <clemens.lange@cern.ch>"
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VCS_URL
+ARG VERSION
+LABEL   org.label-schema.build-date=$BUILD_DATE \
+        org.label-schema.name="SLC5 CMS base OS" \
+        org.label-schema.description="SLC5 OS capable of using/running CMS software release(s)." \
+        org.label-schema.url="http://cms-sw.github.io/" \
+        org.label-schema.vcs-ref=$VCS_REF \
+        org.label-schema.vcs-url=$VCS_URL \
+        org.label-schema.vendor="CERN" \
+        org.label-schema.version=$VERSION \
+        org.label-schema.schema-version="1.0"
+
+# Perform the installation as root
+USER root
+WORKDIR /root
+
+RUN     yum install -y libXft-devel libX11-devel libXpm-devel libXext-devel mesa-libGLU-devel \
+        libXmu libXpm libSM libXft libXext \
+        wget git \
+        glibc-devel \
+        tcsh zsh tcl \
+        perl-libwww-perl \
+        compat-libstdc++-33 zip \
+        voms-clients-cpp \
+        krb5-devel cern-wrappers krb5-workstation \
+        time strace sudo && \
+        yum clean -y all
+
+RUN     wget http://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo && \
+        mv EGI-trustanchors.repo /etc/yum.repos.d/ && \
+        wget http://linuxsoft.cern.ch/wlcg/wlcg-sl5.repo && \
+        mv wlcg-sl5.repo /etc/yum.repos.d/ && \
+        wget http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg && \
+        mv RPM-GPG-KEY-wlcg /etc/pki/rpm-gpg/ && \
+        wget http://grid-deployment.web.cern.ch/grid-deployment/download/HEP/repo/HEP_OSlibs.repo && \
+        mv HEP_OSlibs.repo /etc/yum.repos.d/ && \
+        yum install -y HEP_OSlibs_SL5 ca-policy-lcg ca-policy-egi-core wlcg-repo.noarch wlcg-voms-cms && \
+        yum clean -y all
+
+RUN     groupadd -g 1000 cmsusr && adduser -u 1000 -g 1000 cmsusr && \
+        echo "cmsusr ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers && \
+        groupadd -g 1001 cmsinst && adduser -u 1001 -g 1001 cmsinst && \
+        install -d /opt && install -d -o cmsinst /opt/cms
+
+# Make Images grid/singularity compatible
+RUN mkdir -p /cvmfs /afs /eos /opt/cms
+
+# Add a couple of useful files to cmsusr account
+WORKDIR /home/cmsusr
+USER cmsusr
+ENV USER cmsusr
+ENV HOME /home/cmsusr
+
+ADD dot-pythonrc.py $HOME/.pythonrc.py
+ADD dot-bashrc      $HOME/.bashrc
+ADD dot-bashrc      $HOME/.zshrc
+
+ADD     entrypoint.sh /opt/cms/entrypoint.sh
+RUN     sudo chmod 755 /opt/cms/entrypoint.sh
+
+ENTRYPOINT ["/opt/cms/entrypoint.sh"]
+CMD     ["/bin/zsh"]

--- a/slc5-cms/Makefile
+++ b/slc5-cms/Makefile
@@ -1,0 +1,72 @@
+default: build
+
+# Build Docker image
+build: docker_build output
+
+# Build and push Docker image
+release: docker_build docker_push output
+
+# Image can be overidden with env var.
+DOCKER_IMAGE ?= clelange/slc5-cms
+CERN_IMAGE ?= gitlab-registry.cern.ch/clange/cmssw-docker/slc5-cms
+
+# Get the latest commit.
+GIT_COMMIT = $(strip $(shell git rev-parse --short HEAD))
+
+# Get the date as version number
+CODE_VERSION = $(strip $(shell date +"%Y-%m-%d"))
+
+# Find out if the working directory is clean
+GIT_NOT_CLEAN_CHECK = $(shell git status --porcelain)
+ifneq (x$(GIT_NOT_CLEAN_CHECK), x)
+DOCKER_TAG_SUFFIX = "-dirty"
+endif
+
+# If we're releasing to Docker Hub, and we're going to mark it with the latest tag, it should exactly match a version release
+ifeq ($(MAKECMDGOALS),release)
+# Use the version number as the release tag.
+DOCKER_TAG = $(CODE_VERSION)
+
+# See what commit is tagged to match the version
+VERSION_COMMIT = $(strip $(shell git rev-list $(CODE_VERSION) -n 1 | cut -c1-7))
+ifneq ($(VERSION_COMMIT), $(GIT_COMMIT))
+$(error echo You are trying to push a build based on commit $(GIT_COMMIT) but the tagged release version is $(VERSION_COMMIT))
+endif
+
+# Don't push to Docker Hub if this isn't a clean repo
+ifneq (x$(GIT_NOT_CLEAN_CHECK), x)
+$(error echo You are trying to release a build based on a dirty repo)
+endif
+
+else
+# Add the commit ref for development builds. Mark as dirty if the working directory isn't clean
+DOCKER_TAG = $(CODE_VERSION)-$(GIT_COMMIT)$(DOCKER_TAG_SUFFIX)
+endif
+
+docker_build:
+	# Build Docker image
+	docker build \
+  --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+  --build-arg VERSION=$(CODE_VERSION) \
+  --build-arg VCS_URL=`git config --get remote.origin.url` \
+  --build-arg VCS_REF=$(GIT_COMMIT) \
+	-t $(DOCKER_IMAGE):$(DOCKER_TAG) \
+	--compress --squash .
+	# Tag image as latest
+	docker tag $(DOCKER_IMAGE):$(DOCKER_TAG) $(DOCKER_IMAGE):latest
+
+docker_push:
+	# Tag image also for CERN GitLab container registry
+	docker tag $(DOCKER_IMAGE):$(DOCKER_TAG) $(CERN_IMAGE):$(DOCKER_TAG)
+	docker tag $(DOCKER_IMAGE):$(DOCKER_TAG) $(CERN_IMAGE):latest
+
+	# Push to DockerHub
+	docker push $(DOCKER_IMAGE):$(DOCKER_TAG)
+	docker push $(DOCKER_IMAGE):latest
+
+	# Push to CERN GitLab container registry
+	docker push $(CERN_IMAGE):$(DOCKER_TAG)
+	docker push $(CERN_IMAGE):latest
+
+output:
+	@echo Docker Image: $(DOCKER_IMAGE):$(DOCKER_TAG)

--- a/slc5-cms/dot-bashrc
+++ b/slc5-cms/dot-bashrc
@@ -1,0 +1,7 @@
+## .bashrc/.zshrc
+export PYTHONSTARTUP=$HOME/.pythonrc.py
+export PS1='[\t] \e[91m\u\e[0m@\e[34m\h \e[36m\w \e[0m$ \'
+export PROMPT='[%*] %F{red}%n%f@%F{blue}%m%f %F{yellow}%3~%f $ '
+# define aliases
+alias cmsenv='eval `scramv1 runtime -sh`'
+alias cmsrel='scramv1 project CMSSW'

--- a/slc5-cms/dot-bashrc
+++ b/slc5-cms/dot-bashrc
@@ -1,7 +1,7 @@
 ## .bashrc/.zshrc
 export PYTHONSTARTUP=$HOME/.pythonrc.py
-export PS1='[\t] \e[91m\u\e[0m@\e[34m\h \e[36m\w \e[0m$ \'
-export PROMPT='[%*] %F{red}%n%f@%F{blue}%m%f %F{yellow}%3~%f $ '
+export PS1='[\t] \e[91m\u\e[0m@\e[34m\h \e[36m\w \e[0m$ '
+export PROMPT='[%*] %B%n@%m %3~%b $ '
 # define aliases
 alias cmsenv='eval `scramv1 runtime -sh`'
 alias cmsrel='scramv1 project CMSSW'

--- a/slc5-cms/dot-pythonrc.py
+++ b/slc5-cms/dot-pythonrc.py
@@ -1,0 +1,19 @@
+##
+## for tab-completion
+##
+import rlcompleter, readline
+readline.parse_and_bind('tab: complete')
+readline.parse_and_bind( 'set show-all-if-ambiguous On' )
+
+##
+## for history
+##
+import os, atexit
+histfile = os.path.join(os.environ["HOME"], ".python_history")
+try:
+    readline.read_history_file(histfile)
+except IOError:
+    pass
+atexit.register(readline.write_history_file, histfile)
+del os, atexit, histfile
+del readline

--- a/slc5-cms/entrypoint.sh
+++ b/slc5-cms/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set  -e
+
+echo "::: Setting up CMS environment\
+ (works only if /cvmfs is mounted on host) ..."
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+echo "::: Setting up CMS environment... [done]"
+
+exec "$@"

--- a/slc5-cms/entrypoint.sh
+++ b/slc5-cms/entrypoint.sh
@@ -3,7 +3,10 @@ set  -e
 
 echo "::: Setting up CMS environment\
  (works only if /cvmfs is mounted on host) ..."
-source /cvmfs/cms.cern.ch/cmsset_default.sh
-echo "::: Setting up CMS environment... [done]"
-
+if [ -f /cvmfs/cms.cern.ch/cmsset_default.sh ]; then
+  source /cvmfs/cms.cern.ch/cmsset_default.sh
+  echo "::: Setting up CMS environment... [done]"
+else
+  echo "::: ERROR: Could not set up CMS environment... [done]"
+fi
 exec "$@"


### PR DESCRIPTION
This PR adds an SLC5 container to be able to run CMSSW_4_X_Y.

The entrypoint.sh script is now also nicer and does still allow to start the container when CVMFS is not mounted.